### PR TITLE
[Website] Environment Variables Validation 추가

### DIFF
--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -3,9 +3,4 @@ module.exports = {
   rules: {
     '@next/next/no-html-link-for-pages': 'off',
   },
-  parserOptions: {
-    babelOptions: {
-      presets: [require.resolve('next/babel')],
-    },
-  },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@heroicons/react':
         specifier: ^2.0.18
         version: 2.0.18(react@18.2.0)
+      '@t3-oss/env-nextjs':
+        specifier: ^0.4.0
+        version: 0.4.0(typescript@5.0.4)(zod@3.21.4)
       '@vercel/analytics':
         specifier: ^1.0.1
         version: 1.0.1
@@ -214,6 +217,9 @@ importers:
       sharp:
         specifier: ^0.32.1
         version: 0.32.1
+      zod:
+        specifier: ^3.21.4
+        version: 3.21.4
     devDependencies:
       '@algorithm/eslint-config':
         specifier: workspace:*
@@ -1488,6 +1494,27 @@ packages:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.5.0
+    dev: false
+
+  /@t3-oss/env-core@0.4.0(typescript@5.0.4)(zod@3.21.4):
+    resolution: {integrity: sha512-6JlMp0Vru15q/axHzBKsQQjiyGS6k+EsZBY1iErGVmOGzNSoVluBahnYFP7tEkwZ7KoRgSq4NRIc1Ez7SVYuxQ==}
+    peerDependencies:
+      typescript: '>=4.7.2'
+      zod: ^3.0.0
+    dependencies:
+      typescript: 5.0.4
+      zod: 3.21.4
+    dev: false
+
+  /@t3-oss/env-nextjs@0.4.0(typescript@5.0.4)(zod@3.21.4):
+    resolution: {integrity: sha512-K1u2i+S/uEhjfg++FqWlOzS6x237EARRbWGowH2MkDkFu2q7ZJSiJBJT8e47L7NHWH5IyZrTCM6BdOxyWEnQuQ==}
+    peerDependencies:
+      typescript: '>=4.7.2'
+      zod: ^3.0.0
+    dependencies:
+      '@t3-oss/env-core': 0.4.0(typescript@5.0.4)(zod@3.21.4)
+      typescript: 5.0.4
+      zod: 3.21.4
     dev: false
 
   /@tsconfig/node10@1.0.9:

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "build#website": {
       "dependsOn": ["^build"],
-      "env": ["NEXT_PUBLIC_URL"],
+      "env": ["URL"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "dev": {

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
     },
     "build#website": {
       "dependsOn": ["^build"],
-      "env": ["URL"],
+      "env": ["URL", "NEXT_PUBLIC_URL"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
     "dev": {

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -1,4 +1,9 @@
 module.exports = {
   root: true,
   extends: ['@algorithm/eslint-config/next'],
+  parserOptions: {
+    babelOptions: {
+      presets: [require.resolve('next/babel')],
+    },
+  },
 };

--- a/website/next-sitemap.config.js
+++ b/website/next-sitemap.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next-sitemap').IConfig} */
-
-module.exports = {
-  siteUrl: process.env.VERCEL_URL,
+const config = {
+  siteUrl: process.env.URL,
   generateRobotsTxt: true,
 };
+
+module.exports = config;

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -1,5 +1,7 @@
 import nextra from 'nextra';
 
+import './src/env.mjs';
+
 const withNextra = nextra({
   theme: 'nextra-theme-docs',
   themeConfig: './src/theme.config.tsx',

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "@t3-oss/env-nextjs": "^0.4.0",
     "@vercel/analytics": "^1.0.1",
     "clsx": "^1.2.1",
     "framer-motion": "^10.12.11",
@@ -23,7 +24,8 @@
     "nextra-theme-docs": "^2.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sharp": "^0.32.1"
+    "sharp": "^0.32.1",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@algorithm/eslint-config": "workspace:*",

--- a/website/src/env.mjs
+++ b/website/src/env.mjs
@@ -5,8 +5,11 @@ export const env = createEnv({
   server: {
     URL: z.string().url(),
   },
-  client: {},
+  client: {
+    NEXT_PUBLIC_URL: z.string().url(),
+  },
   runtimeEnv: {
     URL: process.env.URL,
+    NEXT_PUBLIC_URL: process.env.NEXT_PUBLIC_URL,
   },
 });

--- a/website/src/env.mjs
+++ b/website/src/env.mjs
@@ -1,0 +1,12 @@
+import { createEnv } from '@t3-oss/env-nextjs';
+import { z } from 'zod';
+
+export const env = createEnv({
+  server: {
+    URL: z.string().url(),
+  },
+  client: {},
+  runtimeEnv: {
+    URL: process.env.URL,
+  },
+});

--- a/website/src/theme.config.tsx
+++ b/website/src/theme.config.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { Footer } from './components';
 import { Logo } from './components/logos';
 import { Badges, LevelBadge, TopicBadge, ProblemLink } from './components/mdx-components';
+import { env } from './env.mjs';
 
 const config: DocsThemeConfig = {
   project: {
@@ -27,7 +28,7 @@ const config: DocsThemeConfig = {
     const { asPath } = useRouter();
     const { title, frontMatter } = useConfig();
 
-    const baseURL = new URL(process.env.NEXT_PUBLIC_URL);
+    const baseURL = new URL(env.URL);
     const domain = baseURL.hostname;
     const ogImage = new URL('/images/og.png', baseURL).href;
     const url = new URL(asPath, baseURL).href;

--- a/website/src/theme.config.tsx
+++ b/website/src/theme.config.tsx
@@ -28,7 +28,7 @@ const config: DocsThemeConfig = {
     const { asPath } = useRouter();
     const { title, frontMatter } = useConfig();
 
-    const baseURL = new URL(env.URL);
+    const baseURL = new URL(env.NEXT_PUBLIC_URL);
     const domain = baseURL.hostname;
     const ogImage = new URL('/images/og.png', baseURL).href;
     const url = new URL(asPath, baseURL).href;


### PR DESCRIPTION
## Description
- `@t3-oss/env-nextjs`를 통한 Environment Variables Validation과 TypeSafe하게 사용할 수 있도록 수정
- 기존 `eslint-config`에서 `parserOptions`를 수정하던 것을 사용하는 곳에서 변경하도록 수정
  - `next/babel`이 `@algorithm/eslint-config`의 의존성에 포함되지 않아서, 기존 javascript 파일에 대한 eslint가 정상적으로 동작하지 않았음
- Environment Vairables
  - `URL`: Server Side URL
  - `NEXT_PUBLIC_URL`: Client Site URL

## References
- [@t3-oss/t3-env](https://github.com/t3-oss/t3-env)