### PR TITLE
LeetCode 관련 API 오류 수정

### DIFF
--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -1,4 +1,12 @@
 module.exports = {
   root: true,
   extends: ['@algorithm'],
+  rules: {
+    'turbo/no-undeclared-env-vars': [
+      'error',
+      {
+        allowList: ['^LEETCODE'],
+      },
+    ],
+  },
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.5.1",
     "cheerio": "^1.0.0-rc.12",
     "commander": "^11.0.0",
+    "dotenv": "^16.3.1",
     "glob": "^10.3.10",
     "inquirer": "8.2.5",
     "prettier": "^3.0.3",

--- a/packages/cli/src/algorithm.ts
+++ b/packages/cli/src/algorithm.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import path from 'node:path';
 
+import dotenv from 'dotenv';
+
 import { Command } from 'commander';
 
 import {
@@ -9,6 +11,8 @@ import {
   generateProgrammers,
 } from '@/lib/generate';
 import { choiceGenereateTypePrompt, leetCodePrompt, programmersPrompt } from '@/lib/prompt';
+
+dotenv.config();
 
 const program = new Command('Code template Generator for @algorithm');
 

--- a/packages/cli/src/api/leetcode/slug-by-id.ts
+++ b/packages/cli/src/api/leetcode/slug-by-id.ts
@@ -42,7 +42,13 @@ export const getLeetCodeAllProblem = async () => {
     const {
       data: { stat_status_pairs: statStatusPairs },
     } = await axios.get<GetLeetCodeAllQuestionResponse>(`https://leetcode.com/api/problems/all`, {
-      headers: { 'Accept-Encoding': 'gzip,deflate,compress' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
+        Cookie: process.env.LEETCODE_API_COOKIE,
+      },
     });
     return statStatusPairs;
   } catch (error) {

--- a/packages/cli/src/lib/graphql/query.ts
+++ b/packages/cli/src/lib/graphql/query.ts
@@ -8,7 +8,13 @@ interface GraphQLQuery<V> {
 export async function query<D, V = unknown>(url: string, query: GraphQLQuery<V>) {
   const config: AxiosRequestConfig<GraphQLQuery<V>> = {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept-Encoding': 'gzip,deflate,compress' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'User-Agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36',
+      Cookie: process.env.LEETCODE_API_COOKIE,
+    },
     data: query,
   };
 

--- a/packages/cli/src/markdown.ts
+++ b/packages/cli/src/markdown.ts
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 
 import path from 'node:path';
+
+import dotenv from 'dotenv';
+
 import { Command } from 'commander';
 
 import { generateREADME } from './lib/generate';
 import { generatePage } from './lib/generate/page';
+
+dotenv.config();
 
 const program = new Command('Markdown Generator for @algorithm');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       commander:
         specifier: ^11.0.0
         version: 11.0.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.3.1
       glob:
         specifier: ^10.3.10
         version: 10.3.10
@@ -168,7 +171,7 @@ importers:
         version: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.1.1(jest@29.7.0)(typescript@5.2.2)
+        version: 29.1.1(@babel/core@7.23.0)(jest@29.7.0)(typescript@5.2.2)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@20.8.4)(typescript@5.2.2)
@@ -3347,6 +3350,11 @@ packages:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+    dev: false
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
     dev: false
 
   /eastasianwidth@0.2.0:
@@ -8353,7 +8361,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.1.1(jest@29.7.0)(typescript@5.2.2):
+  /ts-jest@29.1.1(@babel/core@7.23.0)(jest@29.7.0)(typescript@5.2.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -8374,6 +8382,7 @@ packages:
       esbuild:
         optional: true
     dependencies:
+      '@babel/core': 7.23.0
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       jest: 29.7.0(@types/node@20.8.4)(ts-node@10.9.1)
@@ -8966,6 +8975,7 @@ packages:
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
     dependencies:
       isexe: 2.0.0
 


### PR DESCRIPTION
## 변경사항
- LeetCode의 API 요청시에 필요한 Cookie가 없는 경우 오류가 발생하는 문제 수정
  - `process.env.LEETCODE_API_COOKIE`의 값을 Cookie로 설정
  - 관련 `eslint-plugin-turbo` 관련 ESLint Rule 수정
- `dotenv` 관련 설정 추가

## 예시
```
#.env
LEETCODE_API_COOKIE="COOKIE"
```
## 참조
- https://leetcode.com/discuss/general-discussion/1297705/is-there-public-api-endpoints-available-for-leetcode
- https://www.npmjs.com/package/dotenv
- https://www.npmjs.com/package/eslint-plugin-turbo
